### PR TITLE
:bug: Fix Unicode identifiers in JVM backends

### DIFF
--- a/backends/Clion/src/main/kotlin/com/yoavst/graffiti/intellij/SocketHolder.kt
+++ b/backends/Clion/src/main/kotlin/com/yoavst/graffiti/intellij/SocketHolder.kt
@@ -29,11 +29,11 @@ object SocketHolder {
             return
         }
         socket.getOutputStream().buffered().let { stream ->
-            val json = Gson().toJson(data)
+            val message = Gson().toJson(data).toByteArray()
             // write length
-            stream.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(json.length).array())
+            stream.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(message.size).array())
             // write data
-            stream.write(json.toByteArray())
+            stream.write(message)
             stream.flush()
         }
     }

--- a/backends/intellij/src/main/kotlin/com/yoavst/graffiti/intellij/SocketHolder.kt
+++ b/backends/intellij/src/main/kotlin/com/yoavst/graffiti/intellij/SocketHolder.kt
@@ -29,11 +29,11 @@ object SocketHolder {
             return
         }
         socket.getOutputStream().buffered().let { stream ->
-            val json = Gson().toJson(data)
+            val message = Gson().toJson(data).toByteArray()
             // write length
-            stream.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(json.length).array())
+            stream.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(message.size).array())
             // write data
-            stream.write(json.toByteArray())
+            stream.write(message)
             stream.flush()
         }
     }

--- a/backends/jadx/graffiti.jadx.kts
+++ b/backends/jadx/graffiti.jadx.kts
@@ -265,10 +265,11 @@ fun sendUpdate(data: Any) {
 
 	val json: String = Gson().toJson(data)
 	jadx.log.debug { "Sending to graffiti: $json" }
+	val message = json.toByteArray()
 
 	socket.getOutputStream().buffered().let { writer ->
-		writer.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(json.length).array())
-		writer.write(json.toByteArray())
+		writer.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(message.size).array())
+		writer.write(message)
 		writer.flush()
 	}
 }

--- a/server/main.py
+++ b/server/main.py
@@ -42,10 +42,11 @@ async def send_ide(request: str, src):
     # We duplicate the lists, to prevent modification of the lists while we use it. 
     # handle_ide_X are reponsible for cleaning the lists in case of a closed socket.
 
+    request_bytes = request.encode('utf-8')
     for _, writer in ide_tcps[:]:
         try:
-            writer.write(struct.pack('>i', len(request)))
-            writer.write(request.encode('utf-8'))
+            writer.write(struct.pack('>i', len(request_bytes)))
+            writer.write(request_bytes)
             await writer.drain()
 
         except socket.error:


### PR DESCRIPTION
Some obfuscators rename identifiers to non-ASCII symbols. Before this fix, the length header was calculated using string length operations, which count character codes instead of bytes