### PR TITLE
Added a popup before deleting a tab

### DIFF
--- a/frontends/web/scripts/TabsController.js
+++ b/frontends/web/scripts/TabsController.js
@@ -290,8 +290,15 @@ class TabsController {
       const contextMenuOpenedForTab = realThis.contextMenuOpenedForTab;
       realThis.contextMenuOpenedForTab = null;
       realThis.contextMenu.classList.remove("visible");
-
-      realThis.#removeTab(contextMenuOpenedForTab);
+      Swal.fire({
+          title: "Remove tab",
+          text: `Are you sure you want to remove tab "${contextMenuOpenedForTab.name}"?`,
+          showCancelButton: true,
+        }).then(({ value = null }) => {
+          if (value != null) {
+            realThis.#removeTab(contextMenuOpenedForTab);
+          }
+        });
     };
 
     this.contextMenu.querySelector("#sources").onclick = function () {

--- a/frontends/web/scripts/main.js
+++ b/frontends/web/scripts/main.js
@@ -513,7 +513,7 @@ function event_searchAll() {
 function event_removeCurrentTab() {
   Swal.fire({
     title: "Remove tab",
-    text: "Are you sure you want to remove the current tab",
+    text: "Are you sure you want to remove the current tab?",
     showCancelButton: true,
   }).then(({ value = null }) => {
     if (value) {


### PR DESCRIPTION
After an unfortunate incident - I would like to merge this feature.
<img width="975" height="507" alt="image" src="https://github.com/user-attachments/assets/da40897e-867b-406d-bad9-a594ca18d059" />
Beforehand there was a confirmation popup only for deleting the current tab when using the command palette.

Yonlif
